### PR TITLE
Allow exponentiation on RHS of multiplication

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ ExponentiationExpression :
 
 MultiplicativeExpression[Yield] :
   ExponentiationExpression[?Yield]
-  MultiplicativeExpression[?Yield] MultiplicativeOperator UnaryExpression[?Yield]
+  MultiplicativeExpression[?Yield] MultiplicativeOperator ExponentiationExpression[?Yield]
 
 MultiplicativeOperator : one of
   * / %


### PR DESCRIPTION
I bet this is just a typo. You're meant to be able to write `a * x**2`, right?
