### PR TITLE
Minor rewording of informative section in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,8 @@ AssignmentOperator : one of
 
 ## Informative
 
-- Commonly used in albegra, geometry, physics and robotics.
-- Nice to have "inline" operator
+- Commonly used in mathematics, physics and robotics.
+- [Infix notation](http://en.wikipedia.org/wiki/Infix_notation) is more succinct than function notation, which makes it more preferable
 
 #### Prior Art
 


### PR DESCRIPTION
There are three changes here:
1. generalizes to state that this will be useful in all fields of mathematics
2. more explicitly describe why this proposal is dope, swapping out 'nice' for 'more succinct'
3. swap 'inline' for 'infix notation'

These are pretty much nbd changes, and I have no idea if the "informative" section even matters for the proposal, so I won't be offended if you close w.o. merge :stuck_out_tongue:
